### PR TITLE
feat: enable extensionless library exports

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -35,6 +35,11 @@
                                                        "default",
                                                        "{workspaceRoot}/.eslintrc.json"
                                                    ]
+                                    },
+                           "@nx/js:tsc": {
+                                        "options": {
+                                                       "generateExportsField": true
+                                                   }
                                     }
                        },
     "namedInputs":  {


### PR DESCRIPTION
## Summary
- enable `generateExportsField` for `@nx/js:tsc` to produce extensionless library exports

## Testing
- `npm test` *(fails: No existing Nx Cloud client and failed to download new version)*

------
https://chatgpt.com/codex/tasks/task_e_68941f54849c83209f7e1e5cd1a77c03