### PR TITLE
refactor(shared): remove .js extensions from exports

### DIFF
--- a/libs/shared/src/core/models/index.ts
+++ b/libs/shared/src/core/models/index.ts
@@ -1,3 +1,3 @@
 // Barrel file for core models
-export * from './notification.model.js';
+export * from './notification.model';
 // Add other models here as needed

--- a/libs/shared/src/enums/index.ts
+++ b/libs/shared/src/enums/index.ts
@@ -1,3 +1,3 @@
 // Barrel file for enums
-export * from './appointment-status.enum.js';
+export * from './appointment-status.enum';
 // Add other enums here as needed

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -1,4 +1,4 @@
-// Re-export everything from submodules with explicit .js extensions for ESM
-export * from './enums/index.js';
-export * from './types/index.js';
-export * from './core/models/index.js';
+// Re-export everything from submodules using extensionless paths for ESM
+export * from './enums/index';
+export * from './types/index';
+export * from './core/models/index';

--- a/libs/shared/src/types/index.ts
+++ b/libs/shared/src/types/index.ts
@@ -1,3 +1,3 @@
 // Barrel file for types
-export * from './user.types.js';
+export * from './user.types';
 // Add other type files here as needed


### PR DESCRIPTION
## Summary
- use extensionless paths for shared library exports

## Testing
- `npx nx lint shared` *(fails: __dirname is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_689426d50eb4832092834832f5e40a89