### PR TITLE
fix: align jest config paths for backend and shared

### DIFF
--- a/libs/backend/jest.config.ts
+++ b/libs/backend/jest.config.ts
@@ -10,11 +10,9 @@ module.exports = {
   collectCoverage: true,
   coverageDirectory: '../../coverage/libs/backend',
   moduleNameMapper: {
-    '^@beauty-saas/(.*)$': '<rootDir>/../../libs/$1/src',
+    '^@backend/(.*)$': '<rootDir>/src/$1',
+    '^@backend-shared/(.*)$': '<rootDir>/src/$1',
+    '^@shared/(.*)$': '<rootDir>/../shared/src/$1',
   },
-  testPathIgnorePatterns: [
-    '/node_modules/',
-    '/dist/',
-    '/e2e/'
-  ]
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/e2e/'],
 };

--- a/libs/backend/tsconfig.json
+++ b/libs/backend/tsconfig.json
@@ -22,8 +22,7 @@
     "paths": {
       "@shared/*": ["../../libs/shared/src/*"],
       "@backend-shared/*": ["../../libs/backend/src/*"],
-      "@backend/*": ["src/*"],
-      "@app/*": ["../../apps/bsaas-front/src/app/*"]
+      "@backend/*": ["src/*"]
     }
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts"],

--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -11,13 +11,12 @@ const config = {
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../../coverage/libs/shared',
   moduleNameMapper: {
-    '^@bsaas/(.*)$': '<rootDir>/../../libs/$1/src',
+    '^@shared/(.*)$': '<rootDir>/src/$1',
+    '^@backend/(.*)$': '<rootDir>/../backend/src/$1',
+    '^@backend-shared/(.*)$': '<rootDir>/../backend/src/$1',
   },
-  testPathIgnorePatterns: [
-    '/node_modules/',
-    '/dist/'
-  ]
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };
 
-// Use module.exports for better compatibility with Nx
+// Export using ESM syntax for ts-jest compatibility
 export default config;

--- a/libs/shared/jest/jest-base.config.ts
+++ b/libs/shared/jest/jest-base.config.ts
@@ -25,7 +25,10 @@ const config: Config.InitialOptions = {
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   moduleNameMapper: {
-    '^@bsaas/(.*)$': '<rootDir>/../../libs/$1/src',
+    '^@shared/(.*)$': '<rootDir>/../../libs/shared/src/$1',
+    '^@backend/(.*)$': '<rootDir>/../../libs/backend/src/$1',
+    '^@backend-shared/(.*)$': '<rootDir>/../../libs/backend/src/$1',
+    '^@frontend/(.*)$': '<rootDir>/../../libs/frontend/src/$1',
   },
   // Add Haste configuration to handle module name collisions
   haste: {
@@ -40,7 +43,6 @@ const config: Config.InitialOptions = {
     '<rootDir>/node_modules',
     '<rootDir>/dist',
     '<rootDir>/coverage',
-    '<rootDir>/apps/.*/dist',
     '<rootDir>/libs/.*/dist',
   ],
   // Reset the module registry before running each test
@@ -52,10 +54,7 @@ const config: Config.InitialOptions = {
   // Restore mock state between tests
   restoreMocks: true,
   // Watch plugins configuration
-  watchPlugins: [
-    'jest-watch-typeahead/filename',
-    'jest-watch-typeahead/testname',
-  ],
+  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
   // Test timeout
   testTimeout: 10000,
 };


### PR DESCRIPTION
## Summary
- map Jest moduleNameMapper to `@backend`, `@backend-shared`, and `@shared` aliases
- drop legacy `@beauty-saas/*` aliases and remove app references from library configs

## Testing
- `npx tsc --noEmit libs/backend/jest.config.ts libs/shared/jest.config.ts libs/shared/jest/jest-base.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_689430c7b0b08320bc5a5e5d38c38cb9